### PR TITLE
fix: replace mock outputs with meaningful resource outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,9 @@ components:
 
 | Name | Description |
 |------|-------------|
-| <a name="output_mock"></a> [mock](#output\_mock) | Mock output example for the Cloud Posse Terraform component template |
+| <a name="output_transit_gateway_route_table_associations"></a> [transit\_gateway\_route\_table\_associations](#output\_transit\_gateway\_route\_table\_associations) | Transit Gateway route table associations |
+| <a name="output_transit_gateway_route_table_propagations"></a> [transit\_gateway\_route\_table\_propagations](#output\_transit\_gateway\_route\_table\_propagations) | Transit Gateway route table propagations |
+| <a name="output_transit_gateway_routes"></a> [transit\_gateway\_routes](#output\_transit\_gateway\_routes) | Transit Gateway static routes |
 <!-- markdownlint-restore -->
 
 
@@ -275,7 +277,7 @@ For additional context, refer to some of these links.
 > - **Customer Workshops.** Engage with our team in weekly workshops, gaining insights and strategies to continuously improve and innovate.
 >
 > <a href="https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse-terraform-components/aws-tgw-routes&utm_content=commercial_support"><img alt="Request Quote" src="https://img.shields.io/badge/request%20quote-success.svg?style=for-the-badge"/></a>
-> 
+>
 </details>
 
 ## ✨ Contributing

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -1,4 +1,14 @@
-output "mock" {
-  description = "Mock output example for the Cloud Posse Terraform component template"
-  value       = local.enabled ? "hello ${basename(abspath(path.module))}" : ""
+output "transit_gateway_route_table_propagations" {
+  description = "Transit Gateway route table propagations"
+  value       = aws_ec2_transit_gateway_route_table_propagation.this
+}
+
+output "transit_gateway_route_table_associations" {
+  description = "Transit Gateway route table associations"
+  value       = aws_ec2_transit_gateway_route_table_association.this
+}
+
+output "transit_gateway_routes" {
+  description = "Transit Gateway static routes"
+  value       = aws_ec2_transit_gateway_route.this
 }


### PR DESCRIPTION
## What
Replace the mock output with meaningful outputs that expose the actual resources created by this component:
- `transit_gateway_route_table_propagations` - Transit Gateway route table propagations
- `transit_gateway_route_table_associations` - Transit Gateway route table associations
- `transit_gateway_routes` - Transit Gateway static routes

## Why
The component was using a template mock output that doesn't provide any useful information. These new outputs expose the actual TGW resources for use by other components or for debugging.

## References
- Follows the same pattern as other components like `aws-vpc-routes`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with new output specifications for Transit Gateway route table operations.

* **New Features**
  * Added three new Terraform outputs for Transit Gateway route table associations, propagations, and static routes configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->